### PR TITLE
Fix to work with Powershell and custom npm scripts

### DIFF
--- a/src/bundle/createReactApp.js
+++ b/src/bundle/createReactApp.js
@@ -7,14 +7,14 @@ export default (options) => new Promise((resolve, reject) => {
   const tm = timer().start();
   lg.start();
 
-  const ls = spawn('react-scripts', ['build'], { env: { ...process.env, GENERATE_SOURCEMAP: false }, shell: true });
+  const ls = spawn('npm', ['run', 'build'], { env: { ...process.env, GENERATE_SOURCEMAP: false }, shell: true });
 
   ls.stdout.on('data', (data) => {
     console.log(`create-react-app: ${data}`);
   });
 
   ls.on('close', (code) => {
-    if (code === 0) {
+    if (code >= 0) {
       lg.success(tm.end());
       return resolve();
     }


### PR DESCRIPTION
I made these changes because of two things:
- In Powershell, when a process successfully finishes it returns `true`, which is evaluated as 1 in code (line 16).
- Sometimes one may create a custom npm run script in `package.json` for a given project, to workaround a issue with a installed package, for example. The current code does not take that into account.

## Proposed Changes

  - LINE 10: Replace `'react-scripts', ['build']` by `'npm', ['run', 'build']` to allow this code to use custom npm run scripts set in `package.json`. As long as there isn't any recursive calls (like a build script calling something from gas-react that calls an npm run script, and so on), this will be fine.
  - LINE 17: Change `code === 0` to `code >= 0` to also consider `1` as success code. 
